### PR TITLE
Update DataCache.cs

### DIFF
--- a/Foreman/DataCache.cs
+++ b/Foreman/DataCache.cs
@@ -302,7 +302,7 @@ namespace Foreman
                 patch = reader.ReadUInt16();
                 dev = reader.ReadUInt16();
 
-                if (minor == 17)
+                if (minor >= 17 )
                 {
                     var noop = reader.ReadByte();
                 }


### PR DESCRIPTION
It looks like there is an empty byte that was added to the mod-settings dat file  between the version delineation and the beginning of the actual property trees in .17, and the handling for that empty byte was targetted only at .17. This fixed, ironically, issue 17 in my testing. 