### PR TITLE
Show Miners/Pumpjacks checkbox fix

### DIFF
--- a/Foreman/Forms/MainForm.Designer.cs
+++ b/Foreman/Forms/MainForm.Designer.cs
@@ -302,6 +302,7 @@
             this.MinerDisplayCheckBox.TabIndex = 0;
             this.MinerDisplayCheckBox.Text = "Display Miners/Pumpjacks";
             this.MinerDisplayCheckBox.UseVisualStyleBackColor = true;
+            this.MinerDisplayCheckBox.CheckedChanged += new System.EventHandler(this.MinerDisplayCheckBox_CheckedChanged);
             // 
             // flowLayoutPanel2
             // 

--- a/Foreman/Forms/MainForm.cs
+++ b/Foreman/Forms/MainForm.cs
@@ -335,7 +335,6 @@ namespace Foreman
 		private void AssemblerDisplayCheckBox_CheckedChanged(object sender, EventArgs e)
 		{
 			GraphViewer.ShowAssemblers = (sender as CheckBox).Checked;
-			GraphViewer.ShowMiners = (sender as CheckBox).Checked;
 			GraphViewer.Graph.UpdateNodeValues();
 			GraphViewer.UpdateNodes();
 		}


### PR DESCRIPTION
Seems like the showminers button at some point had its checkbox event handler removed and its functionality merged in to the show assemblers button, seperating those back out. This seems to resolve issue #23 